### PR TITLE
add lazypair

### DIFF
--- a/src/Knockout.jl
+++ b/src/Knockout.jl
@@ -36,8 +36,8 @@ function knockout(template, data=Dict(), extra_js = js""; computed = [], methods
     watches = Dict()
     for (k, v) in data
         skey = string(k)
-        ko_data[skey] = _get(v)
         (v isa LazyPair) && (v = v.second)
+        ko_data[skey] = isa(v, Observable) ? v[] : v
         if isa(v, Observable)
             # associate the observable with the widget
             setobservable!(widget, skey, v)

--- a/src/Knockout.jl
+++ b/src/Knockout.jl
@@ -9,7 +9,7 @@ export knockout
 const knockout_js = joinpath(@__DIR__, "..", "assets", "knockout.js")
 const knockout_punches_js = joinpath(@__DIR__, "..", "assets", "knockout_punches.js")
 
-include("lazy.jl")
+include("pair.jl")
 
 """
 `knockout(template, data=Dict(), extra_js = js""; computed = [], methods = [])`
@@ -36,7 +36,7 @@ function knockout(template, data=Dict(), extra_js = js""; computed = [], methods
     watches = Dict()
     for (k, v) in data
         skey = string(k)
-        (v isa LazyPair) && (v = v.second)
+        (v isa ObservablePair) && (v = v.second)
         ko_data[skey] = isa(v, Observable) ? v[] : v
         if isa(v, Observable)
             # associate the observable with the widget

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -18,7 +18,3 @@ end
 
 LazyPair(first::Observable; f = identity, g = identity) =
     LazyPair(first, Observable{Any}(f(first[])); f = f, g = g)
-
-_get(x) = x
-_get(x::Observable) = x[]
-_get(x::LazyPair) = _get(x.second)

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -1,6 +1,6 @@
 struct LazyPair{T}
     first::Observable{T}
-    second::Observable{Any}
+    second::Observable
     f
     g
     function LazyPair(first::Observable{T}, second::Observable; f = identity, g = identity) where {T}

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -1,0 +1,20 @@
+struct LazyPair{T}
+    first::Observable{T}
+    second::Observable{Any}
+    f
+    g
+    function LazyPair(first::Observable{T}, second::Observable, f, g) where {T}
+        on(first) do val
+            fval = f(val)
+            (second[] == fval) || Observables.setexcludinghandlers(second, fval, x -> x !== g)
+        end
+        on(second) do val
+            gval = g(val)
+            (first[] == gval) || Observables.setexcludinghandlers(first, gval, x -> x !== f)
+        end
+        new{T}(first, second, f, g)
+    end
+end
+
+LazyPair(first::Observable, second = Observable{Any}(first[]); f = identity, g = identity) =
+    LazyPair(first, second, f, g)

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -21,4 +21,4 @@ LazyPair(first::Observable, second = Observable{Any}(first[]); f = identity, g =
 
 _get(x) = x
 _get(x::Observable) = x[]
-_get(x::LazyPair) = get(x.second)
+_get(x::LazyPair) = _get(x.second)

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -18,3 +18,7 @@ end
 
 LazyPair(first::Observable, second = Observable{Any}(first[]); f = identity, g = identity) =
     LazyPair(first, second, f, g)
+
+_get(x) = x
+_get(x::Observable) = x[]
+_get(x::LazyPair) = get(x.second)

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -3,7 +3,7 @@ struct LazyPair{T}
     second::Observable{Any}
     f
     g
-    function LazyPair(first::Observable{T}, second::Observable, f, g) where {T}
+    function LazyPair(first::Observable{T}, second::Observable; f = identity, g = identity) where {T}
         on(first) do val
             fval = f(val)
             (second[] == fval) || Observables.setexcludinghandlers(second, fval, x -> x !== g)
@@ -16,8 +16,8 @@ struct LazyPair{T}
     end
 end
 
-LazyPair(first::Observable, second = Observable{Any}(first[]); f = identity, g = identity) =
-    LazyPair(first, second, f, g)
+LazyPair(first::Observable; f = identity, g = identity) =
+    LazyPair(first, Observable{Any}(f(first[])); f = f, g = g)
 
 _get(x) = x
 _get(x::Observable) = x[]

--- a/src/pair.jl
+++ b/src/pair.jl
@@ -1,9 +1,9 @@
-struct LazyPair{T}
+struct ObservablePair{T}
     first::Observable{T}
     second::Observable
     f
     g
-    function LazyPair(first::Observable{T}, second::Observable; f = identity, g = identity) where {T}
+    function ObservablePair(first::Observable{T}, second::Observable; f = identity, g = identity) where {T}
         on(first) do val
             fval = f(val)
             (second[] == fval) || Observables.setexcludinghandlers(second, fval, x -> x !== g)
@@ -16,5 +16,5 @@ struct LazyPair{T}
     end
 end
 
-LazyPair(first::Observable; f = identity, g = identity) =
-    LazyPair(first, Observable{Any}(f(first[])); f = f, g = g)
+ObservablePair(first::Observable; f = identity, g = identity) =
+    ObservablePair(first, Observable{Any}(f(first[])); f = f, g = g)

--- a/src/pair.jl
+++ b/src/pair.jl
@@ -1,9 +1,9 @@
-struct ObservablePair{T}
-    first::Observable{T}
-    second::Observable
+struct ObservablePair{S, T}
+    first::Observable{S}
+    second::Observable{T}
     f
     g
-    function ObservablePair(first::Observable{T}, second::Observable; f = identity, g = identity) where {T}
+    function ObservablePair(first::Observable{S}, second::Observable{T}; f = identity, g = identity) where {S, T}
         on(first) do val
             fval = f(val)
             (second[] == fval) || Observables.setexcludinghandlers(second, fval, x -> x !== g)
@@ -12,7 +12,7 @@ struct ObservablePair{T}
             gval = g(val)
             (first[] == gval) || Observables.setexcludinghandlers(first, gval, x -> x !== f)
         end
-        new{T}(first, second, f, g)
+        new{S, T}(first, second, f, g)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,4 +29,6 @@ sleep(1.0)
 @test Blink.@js w document.querySelector("#myselect").children[0].value == "c"
 @test Blink.@js w document.querySelector("#myselect").children[1].value == "d"
 
+include("testpair.jl")
+
 cleanup && AtomShell.uninstall()

--- a/test/testpair.jl
+++ b/test/testpair.jl
@@ -1,0 +1,6 @@
+v = Knockout.ObservablePair(Observable(1.0), f = exp, g = log)
+@test v.second[] ≈ e
+v.first[] = 0
+@test v.second[] ≈ 1
+v.second[] = 2
+@test v.first[] ≈ log(2)


### PR DESCRIPTION
Especially useful for cases where the Julia observable is of a Julia specific type (like Color, or a custom type the user gives). This creates a pair of observables that keep each other in sync, one with the Julia value, the other with the javascript friendly value, subscribed to WebIO.