### PR TITLE
Fix splatting depwarn.

### DIFF
--- a/src/Knockout.jl
+++ b/src/Knockout.jl
@@ -123,7 +123,7 @@ function knockout(template, data=Dict(), extra_js = js""; computed = [], methods
 end
 
 function dict2js(d::AbstractDict)
-    isempty(d) ? js"" : js"$(values(d)...)"
+    isempty(d) ? js"" : js"$(values(d)...,)"
 end
 
 isnumeric(x) = false


### PR DESCRIPTION
One more fix. Results in hard-to-find `jsexpr` error on 1.0 otherwise. Partial stack trace for searchability:

```julia
  Got exception outside of a @test
  MethodError: no method matching jsexpr(::Base.GenericIOBuffer{Array{UInt8,1}}, ::WebIO.JSString, ::WebIO.JSString)
  Closest candidates are:
    jsexpr(::Any, ::Any) at /home/twan/.julia/dev/WebIO/src/syntax.jl:121
  Stacktrace:
   [1] (::getfield(Knockout, Symbol("##13#15")){Dict{Any,Any}})(::Base.GenericIOBuffer{Array{UInt8,1}}) at /home/twan/.julia/dev/WebIO/src/syntax.jl:90
   [2] #sprint#325(::Nothing, ::Int64, ::Function, ::Function) at ./strings/io.jl:101
   [3] sprint at ./strings/io.jl:97 [inlined]
   [4] dict2js at /home/twan/.julia/dev/Knockout/src/Knockout.jl:126 [inlined]
   [5] (::getfield(Knockout, Symbol("##2#7")){WebIO.JSString,Dict{Any,Any},String})(::Base.GenericIOBuffer{Array{UInt8,1}}) at /home/twan/.julia/dev/WebIO/src/syntax.jl:90
   [6] #sprint#325(::Nothing, ::Int64, ::Function, ::Function) at ./strings/io.jl:101
   [7] sprint at ./strings/io.jl:97 [inlined]
   [8] #knockout#1(::Array{Pair{String,WebIO.JSString},1}, ::Array{Any,1}, ::Function, ::WebIO.Node{WebIO.DOM}, ::Array{Pair{String,Observables.Observable},1}, ::WebIO.JSString) at /home/twan/.julia/dev/Knockout/src/Knockout.jl:78
   [9] #knockout at ./none:0 [inlined]
   [10] #input#34(::WebIO.JSString, ::Array{Any,1}, ::Nothing, ::String, ::String, ::String, ::Dict{Any,Any}, ::Nothing, ::Bool, ::WebIO.JSString, ::Dict{Any,Any}, ::String, ::String, ::Base.Iterators.Pairs{Symbol,Float64,Tuple{Symbol,Symbol,Symbol},NamedTuple{(:min, :max, :step),Tuple{Float64,Float64,Float64}}}, ::typeof(Widgets.input), ::InteractBase.NativeHTML, ::Float64) at /home/twan/.julia/packages/InteractBase/YRZ6L/src/input.jl:170
   [11] (::getfield(Widgets, Symbol("#kw##input")))(::NamedTuple{(:displayfunction, :typ, :min, :max, :step, :className),Tuple{WebIO.JSString,String,Float64,Float64,Float64,String}}, ::typeof(Widgets.input), ::InteractBase.NativeHTML, ::Float64) at ./none:0
   [12] #input#159(::Base.Iterators.Pairs{Symbol,Any,NTuple{6,Symbol},NamedTuple{(:displayfunction, :typ, :min, :max, :step, :className),Tuple{WebIO.JSString,String,Float64,Float64,Float64,String}}}, ::Function, ::Float64) at /home/twan/.julia/packages/InteractBase/YRZ6L/src/defaults.jl:12
   [13] #input at ./none:0 [inlined]
   [14] #slider#63(::String, ::Bool, ::Bool, ::Nothing, ::String, ::Float64, ::Int64, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(InteractBase.slider), ::InteractBase.NativeHTML, ::StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}}) at /home/twan/.julia/packages/InteractBase/YRZ6L/src/input.jl:318
   [15] (::getfield(InteractBase, Symbol("#kw##slider")))(::NamedTuple{(:value, :label),Tuple{Float64,String}}, ::typeof(InteractBase.slider), ::InteractBase.NativeHTML, ::StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}}) at ./none:0
   [16] #slider#175(::Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:value, :label),Tuple{Float64,String}}}, ::Function, ::StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}}) at /home/twan/.julia/packages/InteractBase/YRZ6L/src/defaults.jl:12
```